### PR TITLE
Set up Mocha and add sample test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "step-intern-2020-v2",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha --recursive portfolio/src/main/webapp"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/googleinterns/step61-2020.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/googleinterns/step61-2020/issues"
+  },
+  "homepage": "https://github.com/googleinterns/step61-2020#readme",
+  "dependencies": {
+    "mocha": "^8.0.1"
+  }
+}

--- a/portfolio/src/main/webapp/calendar_test.js
+++ b/portfolio/src/main/webapp/calendar_test.js
@@ -1,0 +1,10 @@
+var assert = require('assert');
+
+// TODO(hollyyuqizheng): Update the test.
+describe('Foo', function () {
+  describe('Bar', function () {
+    it('Bazz', function () {
+      assert.equal(2, 1 + 1);
+    });
+  });
+});


### PR DESCRIPTION
Set up Mocha for Javascript unit testing. With this change, one can run `npm test` in the repro directory, and it will run the mocha tests.