### PR TITLE
Add a .equals() for CalendarEvent

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/CalendarEvent.java
+++ b/portfolio/src/main/java/com/google/sps/data/CalendarEvent.java
@@ -48,4 +48,14 @@ public class CalendarEvent {
   public Instant getEndTime() {
     return endTime;
   }
+  @Override
+  public boolean equals(Object other) {
+    return other instanceof CalendarEvent && equals(this, (CalendarEvent) other);
+  }
+
+  public static boolean equals(CalendarEvent a, CalendarEvent b) {
+    return a.name.equals(b.name)
+        && a.startTime.equals(b.startTime)
+        && a.endTime.equals(b.endTime);
+  }
 }

--- a/portfolio/src/main/java/com/google/sps/data/CalendarEvent.java
+++ b/portfolio/src/main/java/com/google/sps/data/CalendarEvent.java
@@ -48,6 +48,7 @@ public class CalendarEvent {
   public Instant getEndTime() {
     return endTime;
   }
+  
   @Override
   public boolean equals(Object other) {
     return other instanceof CalendarEvent && equals(this, (CalendarEvent) other);


### PR DESCRIPTION
This PR just adds a .equals() to the CalendarEvent class. In a recent PR I added some tests for ServletHelper.java and after pulling master I realized these tests are failing. Without the overrided .equals(), which I forgot to include in that PR, these tests are checking whether the CalendarEvents are the same object and not whether the fields are the same. 