### PR TITLE
Longest task first with task split-up logic

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/ArrayListTimeRangeGroup.java
+++ b/portfolio/src/main/java/com/google/sps/data/ArrayListTimeRangeGroup.java
@@ -1,5 +1,6 @@
 package com.google.sps.data;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -188,5 +189,14 @@ public class ArrayListTimeRangeGroup implements TimeRangeGroup, Iterable<TimeRan
     }
 
     allTimeRanges = newTimeRanges;
+  }
+
+  /** Returns the total duration of the list of time ranges. */
+  public Duration getTotalDuration() {
+    Duration totalDuration = Duration.ofSeconds(0);
+    for (TimeRange range : allTimeRanges) {
+      totalDuration = totalDuration.plus(range.duration());
+    }
+    return totalDuration;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/data/ArrayListTimeRangeGroup.java
+++ b/portfolio/src/main/java/com/google/sps/data/ArrayListTimeRangeGroup.java
@@ -1,6 +1,5 @@
 package com.google.sps.data;
 
-import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -189,14 +188,5 @@ public class ArrayListTimeRangeGroup implements TimeRangeGroup, Iterable<TimeRan
     }
 
     allTimeRanges = newTimeRanges;
-  }
-
-  /** Returns the total duration of the list of time ranges. */
-  public Duration getTotalDuration() {
-    Duration totalDuration = Duration.ofSeconds(0);
-    for (TimeRange range : allTimeRanges) {
-      totalDuration = totalDuration.plus(range.duration());
-    }
-    return totalDuration;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/data/LongestTaskFirstScheduler.java
+++ b/portfolio/src/main/java/com/google/sps/data/LongestTaskFirstScheduler.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.List;
 
 /** This class models a scheduling algorithm that prioritizes scheduling longer tasks first. */
@@ -59,7 +58,6 @@ public class LongestTaskFirstScheduler implements TaskScheduler {
 
   /** Constructs a list for the updated available time ranges after deletion. */
   private List<TimeRange> constructAvailableTimeRanges(TimeRangeGroup updatedTimeRangeGroup) {
-    Iterator<TimeRange> updatedAvailableTimesGroupIterator = updatedTimeRangeGroup.iterator();
     List<TimeRange> updatedAvailableTimes = new ArrayList();
     updatedTimeRangeGroup.iterator().forEachRemaining(updatedAvailableTimes::add);
     return updatedAvailableTimes;

--- a/portfolio/src/main/java/com/google/sps/data/LongestTaskFirstScheduler.java
+++ b/portfolio/src/main/java/com/google/sps/data/LongestTaskFirstScheduler.java
@@ -120,7 +120,9 @@ public class LongestTaskFirstScheduler implements TaskScheduler {
 
   /**
    * Keeps splitting up the task to schedule the currently avaible free time ranges until all of the
-   * task is scheduled across the different time ranges.
+   * task is scheduled across the different time ranges. When this method is called, the task
+   * duration has already been checked against current free time range and this task is for sure
+   * able to be scheduled.
    */
   private void splitUpTaskToSchedule(
       Task task, TimeRangeGroup availableTimesGroup, List<ScheduledTask> scheduledTasks) {

--- a/portfolio/src/main/java/com/google/sps/data/LongestTaskFirstScheduler.java
+++ b/portfolio/src/main/java/com/google/sps/data/LongestTaskFirstScheduler.java
@@ -131,18 +131,35 @@ public class LongestTaskFirstScheduler implements TaskScheduler {
 
     for (TimeRange currentFreeTimeRange : currentAvailableTimes) {
       if (taskDuration.getSeconds() > 0) {
-        // Construct the scheduled task object.
         Instant scheduledTime = currentFreeTimeRange.start();
-        ScheduledTask scheduledTask = new ScheduledTask(task, scheduledTime);
-        scheduledTasks.add(scheduledTask);
+
+        String taskName = task.getName();
+        String taskDescription = "";
+        if (task.getDescription().isPresent()) {
+          taskDescription = task.getDescription().get();
+        }
+        TaskPriority taskPriority = task.getPriority();
 
         // If task's current duration is longer than the free time's,
         // this means the entirety of the free time range is scheduled to this task.
         if (taskDuration.compareTo(currentFreeTimeRange.duration()) > 0) {
+          // Constructs a new taks object with the current free time range's duration.
+          Task taskWithActualScheduledDuration =
+              new Task(taskName, taskDescription, currentFreeTimeRange.duration(), taskPriority);
+          ScheduledTask scheduledTask =
+              new ScheduledTask(taskWithActualScheduledDuration, scheduledTime);
+          scheduledTasks.add(scheduledTask);
+
           availableTimesGroup.deleteTimeRange(currentFreeTimeRange);
           taskDuration = taskDuration.minus(currentFreeTimeRange.duration());
         } else {
           // Otherwise, only part of the free time range is needed to schedule this task.
+          Task taskWithActualScheduledDuration =
+              new Task(taskName, taskDescription, taskDuration, taskPriority);
+          ScheduledTask scheduledTask =
+              new ScheduledTask(taskWithActualScheduledDuration, scheduledTime);
+          scheduledTasks.add(scheduledTask);
+
           Instant scheduledTaskEndTime = scheduledTime.plus(taskDuration);
           TimeRange scheduledTaskTimeRange =
               TimeRange.fromStartEnd(scheduledTime, scheduledTaskEndTime);

--- a/portfolio/src/main/java/com/google/sps/data/TimeRangeGroup.java
+++ b/portfolio/src/main/java/com/google/sps/data/TimeRangeGroup.java
@@ -1,6 +1,5 @@
 package com.google.sps.data;
 
-import java.time.Duration;
 import java.util.Iterator;
 
 public interface TimeRangeGroup {
@@ -28,7 +27,4 @@ public interface TimeRangeGroup {
 
   /** Returns an iterator for the collection of all time ranges. */
   public Iterator<TimeRange> iterator();
-
-  /** Returns the total duration of all time ranges in the collection. */
-  public Duration getTotalDuration();
 }

--- a/portfolio/src/main/java/com/google/sps/data/TimeRangeGroup.java
+++ b/portfolio/src/main/java/com/google/sps/data/TimeRangeGroup.java
@@ -1,5 +1,6 @@
 package com.google.sps.data;
 
+import java.time.Duration;
 import java.util.Iterator;
 
 public interface TimeRangeGroup {
@@ -26,6 +27,8 @@ public interface TimeRangeGroup {
   public void deleteTimeRange(TimeRange timeRangeToDelete);
 
   /** Returns an iterator for the collection of all time ranges. */
-  // public Iterator<TimeRange> getAllTimeRangesIterator();
   public Iterator<TimeRange> iterator();
+
+  /** Returns the total duration of all time ranges in the collection. */
+  public Duration getTotalDuration();
 }

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -278,6 +278,7 @@
           <div class="input-group input-group-lg" id="algorithm-menu-wrapper">
             <select class="custom-select" id="algorithm-type">
               <option value="SHORTEST_TASK_FIRST">Shortest Tasks First</option>
+              <option value="LONGEST_TASK_FIRST">Longest Tasks First</option>
             </select>
             <div class="input-group-append">
               <button class="btn btn-success" type="button" onclick="onClickStartScheduling()">

--- a/portfolio/src/test/java/com/google/sps/ArrayListTimeRangeGroupTest.java
+++ b/portfolio/src/test/java/com/google/sps/ArrayListTimeRangeGroupTest.java
@@ -1,6 +1,5 @@
 package com.google.sps.data;
 
-import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -710,24 +709,5 @@ public final class ArrayListTimeRangeGroupTest {
 
     Collections.sort(actual, TimeRange.SORT_BY_TIME_RANGE_DURATION_ASCENDING_THEN_START_TIME);
     Assert.assertEquals(expectedTimeRangesAfterDelete, actual);
-  }
-
-  /** Tests for the getTotalDuration method. */
-  @Test
-  public void testTotalDuration() {
-    Instant timeRangeOneStart = Instant.now();
-    Instant timeRangeOneEnd = timeRangeOneStart.plusSeconds(1000);
-    Instant timeRangeTwoStart = timeRangeOneEnd.plusSeconds(1000);
-    Instant timeRangeTwoEnd = timeRangeTwoStart.plusSeconds(1000);
-
-    TimeRange timeRangeOne = TimeRange.fromStartEnd(timeRangeOneStart, timeRangeOneEnd);
-    TimeRange timeRangeTwo = TimeRange.fromStartEnd(timeRangeTwoStart, timeRangeTwoEnd);
-
-    List<TimeRange> timeRanges = Arrays.asList(timeRangeOne, timeRangeTwo);
-    ArrayListTimeRangeGroup timeRangeGroup = new ArrayListTimeRangeGroup(timeRanges);
-
-    Duration expected = Duration.ofSeconds(2000);
-    Duration actual = timeRangeGroup.getTotalDuration();
-    Assert.assertEquals(actual, expected);
   }
 }

--- a/portfolio/src/test/java/com/google/sps/ArrayListTimeRangeGroupTest.java
+++ b/portfolio/src/test/java/com/google/sps/ArrayListTimeRangeGroupTest.java
@@ -1,5 +1,6 @@
 package com.google.sps.data;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -598,5 +599,24 @@ public final class ArrayListTimeRangeGroupTest {
 
     Collections.sort(actual, TimeRange.SORT_BY_TIME_RANGE_DURATION_ASCENDING_THEN_START_TIME);
     Assert.assertEquals(expectedTimeRangesAfterDelete, actual);
+  }
+
+  /** Tests for the getTotalDuration method. */
+  @Test
+  public void testTotalDuration() {
+    Instant timeRangeOneStart = Instant.now();
+    Instant timeRangeOneEnd = timeRangeOneStart.plusSeconds(1000);
+    Instant timeRangeTwoStart = timeRangeOneEnd.plusSeconds(1000);
+    Instant timeRangeTwoEnd = timeRangeTwoStart.plusSeconds(1000);
+
+    TimeRange timeRangeOne = TimeRange.fromStartEnd(timeRangeOneStart, timeRangeOneEnd);
+    TimeRange timeRangeTwo = TimeRange.fromStartEnd(timeRangeTwoStart, timeRangeTwoEnd);
+
+    List<TimeRange> timeRanges = Arrays.asList(timeRangeOne, timeRangeTwo);
+    ArrayListTimeRangeGroup timeRangeGroup = new ArrayListTimeRangeGroup(timeRanges);
+
+    Duration expected = Duration.ofSeconds(2000);
+    Duration actual = timeRangeGroup.getTotalDuration();
+    Assert.assertEquals(actual, expected);
   }
 }

--- a/portfolio/src/test/java/com/google/sps/LongestTaskFirstSchedulerTest.java
+++ b/portfolio/src/test/java/com/google/sps/LongestTaskFirstSchedulerTest.java
@@ -82,32 +82,6 @@ public final class LongestTaskFirstSchedulerTest {
     Assert.assertEquals(expected, tasks);
   }
 
-  /** Tests for the task renaming method. */
-  @Test
-  public void testTaskRenaming() {
-    Task task1 =
-        new Task(
-            "Task A (Part 1)",
-            "A",
-            SchedulerTestUtil.DURATION_20_MINUTES,
-            SchedulerTestUtil.PRIORITY_ONE);
-    ScheduledTask scheduledTask1 = new ScheduledTask(task1, SchedulerTestUtil.TIME_0900);
-    ScheduledTask scheduledTask1After =
-        LongestTaskFirstScheduler.changeTaskNameToOriginal(scheduledTask1);
-    Assert.assertEquals(scheduledTask1After.getTask().getName(), "Task A");
-
-    Task task2 =
-        new Task(
-            "(Weird name) (Part 1)",
-            "A",
-            SchedulerTestUtil.DURATION_20_MINUTES,
-            SchedulerTestUtil.PRIORITY_ONE);
-    ScheduledTask scheduledTask2 = new ScheduledTask(task2, SchedulerTestUtil.TIME_0900);
-    ScheduledTask scheduledTask2After =
-        LongestTaskFirstScheduler.changeTaskNameToOriginal(scheduledTask2);
-    Assert.assertEquals(scheduledTask2After.getTask().getName(), "(Weird name)");
-  }
-
   /**
    * Tests for a basic scenario where all free time ranges can be scheduled. Tests for the ordering
    * of the test (longest task first).
@@ -198,6 +172,59 @@ public final class LongestTaskFirstSchedulerTest {
             "B",
             SchedulerTestUtil.DURATION_60_MINUTES,
             SchedulerTestUtil.PRIORITY_ONE);
+
+    ScheduledTask scheduledTask1 = new ScheduledTask(task1A, SchedulerTestUtil.TIME_0900);
+    ScheduledTask scheduledTask2 = new ScheduledTask(task1B, SchedulerTestUtil.TIME_1000);
+    ScheduledTask scheduledTask3 = new ScheduledTask(task2A, SchedulerTestUtil.TIME_1200);
+    Collection<ScheduledTask> expected =
+        Arrays.asList(scheduledTask1, scheduledTask2, scheduledTask3);
+
+    Assert.assertEquals(actual, expected);
+  }
+
+  /**
+   * Tests for the scenario where one task is scheduled completely in segments, while the other one
+   * is completely scheduled.
+   */
+  @Test
+  public void testOneTaskSplitOtherWhole() {
+    // Working hours:   |-----------------------------------------------------|
+    // Events:                 |---|          |--------|    |-----------------|
+    // Scheduled:       |--A---|   |-----A----|        |--B-|
+    Collection<CalendarEvent> events =
+        Arrays.asList(
+            new CalendarEvent("Event 1", SchedulerTestUtil.TIME_0930, SchedulerTestUtil.TIME_1000),
+            new CalendarEvent("Event 2", SchedulerTestUtil.TIME_1130, SchedulerTestUtil.TIME_1200),
+            new CalendarEvent("Event 3", SchedulerTestUtil.TIME_1300, SchedulerTestUtil.TIME_1700));
+
+    Task task1 =
+        new Task("Task A", "A", SchedulerTestUtil.DURATION_2_HOURS, SchedulerTestUtil.PRIORITY_ONE);
+    Task task2 =
+        new Task(
+            "Task B", "B", SchedulerTestUtil.DURATION_60_MINUTES, SchedulerTestUtil.PRIORITY_ONE);
+    Collection<Task> tasks = Arrays.asList(task1, task2);
+
+    LongestTaskFirstScheduler longestTaskFirstScheduler = new LongestTaskFirstScheduler();
+    Collection<ScheduledTask> actual =
+        longestTaskFirstScheduler.schedule(
+            events, tasks, SchedulerTestUtil.TIME_0900, SchedulerTestUtil.TIME_1700);
+
+    // These are the shortened segments of task A.
+    Task task1A =
+        new Task(
+            "Task A (Part 1)",
+            "A",
+            SchedulerTestUtil.DURATION_30_MINUTES,
+            SchedulerTestUtil.PRIORITY_ONE);
+    Task task1B =
+        new Task(
+            "Task A (Part 2)",
+            "A",
+            SchedulerTestUtil.DURATION_90_MINUTES,
+            SchedulerTestUtil.PRIORITY_ONE);
+    Task task2A =
+        new Task(
+            "Task B", "B", SchedulerTestUtil.DURATION_60_MINUTES, SchedulerTestUtil.PRIORITY_ONE);
 
     ScheduledTask scheduledTask1 = new ScheduledTask(task1A, SchedulerTestUtil.TIME_0900);
     ScheduledTask scheduledTask2 = new ScheduledTask(task1B, SchedulerTestUtil.TIME_1000);

--- a/portfolio/src/test/java/com/google/sps/LongestTaskFirstSchedulerTest.java
+++ b/portfolio/src/test/java/com/google/sps/LongestTaskFirstSchedulerTest.java
@@ -82,6 +82,32 @@ public final class LongestTaskFirstSchedulerTest {
     Assert.assertEquals(expected, tasks);
   }
 
+  /** Tests for the task renaming method. */
+  @Test
+  public void testTaskRenaming() {
+    Task task1 =
+        new Task(
+            "Task A (Part 1)",
+            "A",
+            SchedulerTestUtil.DURATION_20_MINUTES,
+            SchedulerTestUtil.PRIORITY_ONE);
+    ScheduledTask scheduledTask1 = new ScheduledTask(task1, SchedulerTestUtil.TIME_0900);
+    ScheduledTask scheduledTask1After =
+        LongestTaskFirstScheduler.changeTaskNameToOriginal(scheduledTask1);
+    Assert.assertEquals(scheduledTask1After.getTask().getName(), "Task A");
+
+    Task task2 =
+        new Task(
+            "(Weird name) (Part 1)",
+            "A",
+            SchedulerTestUtil.DURATION_20_MINUTES,
+            SchedulerTestUtil.PRIORITY_ONE);
+    ScheduledTask scheduledTask2 = new ScheduledTask(task2, SchedulerTestUtil.TIME_0900);
+    ScheduledTask scheduledTask2After =
+        LongestTaskFirstScheduler.changeTaskNameToOriginal(scheduledTask2);
+    Assert.assertEquals(scheduledTask2After.getTask().getName(), "(Weird name)");
+  }
+
   /**
    * Tests for a basic scenario where all free time ranges can be scheduled. Tests for the ordering
    * of the test (longest task first).
@@ -117,6 +143,10 @@ public final class LongestTaskFirstSchedulerTest {
     ScheduledTask scheduledTask2 = new ScheduledTask(task2, SchedulerTestUtil.TIME_1020);
     Collection<ScheduledTask> expected =
         Arrays.asList(scheduledTask1, scheduledTask3, scheduledTask2);
+
+    for (ScheduledTask t : actual) {
+      System.out.println(t.getTask().getName());
+    }
 
     Assert.assertEquals(actual, expected);
   }

--- a/portfolio/src/test/java/com/google/sps/LongestTaskFirstSchedulerTest.java
+++ b/portfolio/src/test/java/com/google/sps/LongestTaskFirstSchedulerTest.java
@@ -146,8 +146,16 @@ public final class LongestTaskFirstSchedulerTest {
         longestTaskFirstScheduler.schedule(
             events, tasks, SchedulerTestUtil.TIME_0900, SchedulerTestUtil.TIME_1700);
 
-    ScheduledTask scheduledTask1 = new ScheduledTask(task1, SchedulerTestUtil.TIME_0900);
-    ScheduledTask scheduledTask2 = new ScheduledTask(task1, SchedulerTestUtil.TIME_1000);
+    // These are the shortened segments of task A.
+    Task task1A =
+        new Task(
+            "Task A", "A", SchedulerTestUtil.DURATION_30_MINUTES, SchedulerTestUtil.PRIORITY_ONE);
+    Task task1B =
+        new Task(
+            "Task A", "A", SchedulerTestUtil.DURATION_90_MINUTES, SchedulerTestUtil.PRIORITY_ONE);
+
+    ScheduledTask scheduledTask1 = new ScheduledTask(task1A, SchedulerTestUtil.TIME_0900);
+    ScheduledTask scheduledTask2 = new ScheduledTask(task1B, SchedulerTestUtil.TIME_1000);
     Collection<ScheduledTask> expected = Arrays.asList(scheduledTask1, scheduledTask2);
 
     Assert.assertEquals(actual, expected);
@@ -189,21 +197,27 @@ public final class LongestTaskFirstSchedulerTest {
     Collection<ScheduledTask> actual =
         longestTaskFirstScheduler.schedule(
             events, tasks, SchedulerTestUtil.TIME_0900, SchedulerTestUtil.TIME_1700);
-    ScheduledTask scheduledTask1 = new ScheduledTask(task1, SchedulerTestUtil.TIME_0900);
-    ScheduledTask scheduledTask2 = new ScheduledTask(task1, SchedulerTestUtil.TIME_1000);
-    ScheduledTask scheduledTask3 = new ScheduledTask(task3, SchedulerTestUtil.TIME_1200);
-    ScheduledTask scheduledTask4 = new ScheduledTask(task3, SchedulerTestUtil.TIME_1500);
+
+    Task task1A =
+        new Task(
+            "Task A", "A", SchedulerTestUtil.DURATION_30_MINUTES, SchedulerTestUtil.PRIORITY_ONE);
+    Task task1B =
+        new Task(
+            "Task A", "A", SchedulerTestUtil.DURATION_90_MINUTES, SchedulerTestUtil.PRIORITY_ONE);
+    Task task3A =
+        new Task(
+            "Task C", "C", SchedulerTestUtil.DURATION_60_MINUTES, SchedulerTestUtil.PRIORITY_ONE);
+    Task task3B =
+        new Task(
+            "Task C", "C", SchedulerTestUtil.DURATION_20_MINUTES, SchedulerTestUtil.PRIORITY_ONE);
+    ScheduledTask scheduledTask1 = new ScheduledTask(task1A, SchedulerTestUtil.TIME_0900);
+    ScheduledTask scheduledTask2 = new ScheduledTask(task1B, SchedulerTestUtil.TIME_1000);
+    ScheduledTask scheduledTask3 = new ScheduledTask(task3A, SchedulerTestUtil.TIME_1200);
+    ScheduledTask scheduledTask4 = new ScheduledTask(task3B, SchedulerTestUtil.TIME_1500);
     ScheduledTask scheduledTask5 = new ScheduledTask(task4, SchedulerTestUtil.TIME_1520);
     Collection<ScheduledTask> expected =
         Arrays.asList(
             scheduledTask1, scheduledTask2, scheduledTask3, scheduledTask4, scheduledTask5);
-
-    // System.out.println("-----");
-    // for (ScheduledTask t : actual) {
-    //   System.out.println(t.getTask().getName());
-    //   System.out.println(t.getStartTime());
-    // }
-    // System.out.println("-----");
 
     Assert.assertEquals(actual, expected);
   }
@@ -282,5 +296,29 @@ public final class LongestTaskFirstSchedulerTest {
     Collection<ScheduledTask> expected = Arrays.asList(scheduledTask3, scheduledTask1);
 
     Assert.assertEquals(actual, expected);
+  }
+
+  /** Tests for the scenario where no task can be scheduled. */
+  @Test
+  public void testNoTaskScheduled() {
+    // Working hours:   |-----------------------------------------|
+    // Events:               |---|     |--------------------------|
+    // Scheduled tasks:
+    Collection<CalendarEvent> events =
+        Arrays.asList(
+            new CalendarEvent("Event 1", SchedulerTestUtil.TIME_0930, SchedulerTestUtil.TIME_1000),
+            new CalendarEvent("Event 2", SchedulerTestUtil.TIME_1030, SchedulerTestUtil.TIME_1700));
+
+    Task task1 =
+        new Task(
+            "Task A", "A", SchedulerTestUtil.DURATION_80_MINUTES, SchedulerTestUtil.PRIORITY_ONE);
+    Collection<Task> tasks = Arrays.asList(task1);
+
+    LongestTaskFirstScheduler longestTaskFirstScheduler = new LongestTaskFirstScheduler();
+    Collection<ScheduledTask> actual =
+        longestTaskFirstScheduler.schedule(
+            events, tasks, SchedulerTestUtil.TIME_0900, SchedulerTestUtil.TIME_1700);
+
+    Assert.assertTrue(actual.isEmpty());
   }
 }

--- a/portfolio/src/test/java/com/google/sps/SchedulerTestUtil.java
+++ b/portfolio/src/test/java/com/google/sps/SchedulerTestUtil.java
@@ -27,6 +27,7 @@ public class SchedulerTestUtil {
   public static final Instant TIME_1000 = TIME_0900.plus(DURATION_60_MINUTES);
   public static final Instant TIME_1020 = TIME_1000.plus(DURATION_20_MINUTES);
   public static final Instant TIME_1030 = TIME_1000.plus(DURATION_30_MINUTES);
+  public static final Instant TIME_1050 = TIME_1030.plus(DURATION_20_MINUTES);
   public static final Instant TIME_1100 = TIME_1000.plus(DURATION_60_MINUTES);
   public static final Instant TIME_1120 = TIME_1100.plus(DURATION_20_MINUTES);
   public static final Instant TIME_1130 = TIME_1030.plus(DURATION_60_MINUTES);
@@ -34,6 +35,8 @@ public class SchedulerTestUtil {
   public static final Instant TIME_1300 = TIME_1200.plus(DURATION_60_MINUTES);
   public static final Instant TIME_1400 = TIME_1300.plus(DURATION_60_MINUTES);
   public static final Instant TIME_1500 = TIME_1400.plus(DURATION_60_MINUTES);
+  public static final Instant TIME_1520 = TIME_1500.plus(DURATION_20_MINUTES);
+  public static final Instant TIME_1530 = TIME_1500.plus(DURATION_30_MINUTES);
   public static final Instant TIME_1600 = TIME_1500.plus(DURATION_60_MINUTES);
   public static final Instant TIME_1700 = TIME_1600.plus(DURATION_60_MINUTES);
   public static final Instant TIME_1800 = TIME_1700.plus(DURATION_60_MINUTES);

--- a/portfolio/src/test/java/com/google/sps/SchedulerTestUtil.java
+++ b/portfolio/src/test/java/com/google/sps/SchedulerTestUtil.java
@@ -13,6 +13,7 @@ public class SchedulerTestUtil {
   public static final Duration DURATION_15_MINUTES = Duration.ofSeconds(15 * 60);
   public static final Duration DURATION_20_MINUTES = Duration.ofSeconds(20 * 60);
   public static final Duration DURATION_30_MINUTES = Duration.ofSeconds(30 * 60);
+  public static final Duration DURATION_40_MINUTES = Duration.ofSeconds(40 * 60);
   public static final Duration DURATION_45_MINUTES = Duration.ofSeconds(45 * 60);
   public static final Duration DURATION_60_MINUTES = Duration.ofSeconds(60 * 60);
   public static final Duration DURATION_80_MINUTES = Duration.ofSeconds(80 * 60);

--- a/portfolio/src/test/java/com/google/sps/SchedulerTestUtil.java
+++ b/portfolio/src/test/java/com/google/sps/SchedulerTestUtil.java
@@ -16,6 +16,7 @@ public class SchedulerTestUtil {
   public static final Duration DURATION_45_MINUTES = Duration.ofSeconds(45 * 60);
   public static final Duration DURATION_60_MINUTES = Duration.ofSeconds(60 * 60);
   public static final Duration DURATION_80_MINUTES = Duration.ofSeconds(80 * 60);
+  public static final Duration DURATION_90_MINUTES = Duration.ofSeconds(90 * 60);
   public static final Duration DURATION_100_MINUTES = Duration.ofSeconds(100 * 60);
   public static final Duration DURATION_2_HOURS = Duration.ofSeconds(120 * 60);
 


### PR DESCRIPTION
I updated the longest task first algorithm so that long tasks that cannot be scheduled into one time range can be broken into smaller segments and be scheduled this way. I also added a new method to the TimeRangeGroup interface. 